### PR TITLE
[Fix] campaign setup notification drop downs

### DIFF
--- a/app/controllers/account/anatomy/company-users/new.js
+++ b/app/controllers/account/anatomy/company-users/new.js
@@ -13,9 +13,9 @@ export default Controller.extend(addEdit, {
 
   actions: {
     async save () {
-      let model = this.get('model');
-      let employee = await this.get('model.employee');
-      let user = await this.saveModel(model);
+      let model = this.get('model'),
+          employee = await this.get('model.employee'),
+          user = await this.saveModel(model);
 
       employee.set('companyUser', user);
       await this.saveModel(employee);

--- a/app/controllers/account/anatomy/company-users/new.js
+++ b/app/controllers/account/anatomy/company-users/new.js
@@ -12,6 +12,15 @@ export default Controller.extend(addEdit, {
   }),
 
   actions: {
+    async save () {
+      let model = this.get('model');
+      let employee = await this.get('model.employee');
+      let user = await this.saveModel(model);
+
+      employee.set('companyUser', user);
+      await this.saveModel(employee);
+    },
+
     presetAttrs () {
       let model = this.get('model'),
           employee = this.get('model.employee'),


### PR DESCRIPTION
link created between company user and employee upon creation of company user will fill drop down.  additional email dropdown works as expected

closes #477 