### PR TITLE
[Bug] Recruiting pipeline decline to hire in the modal does nothing

### DIFF
--- a/app/components/confirm-modal.js
+++ b/app/components/confirm-modal.js
@@ -56,7 +56,7 @@ export default Component.extend({
         return;
       }
       let fn = this.get(response ? 'resolve' : 'reject');
-      fn.apply(null, response ? this.get('_originalArgs'):null);
+      fn.apply(null, response ? this.get('_originalArgs') : null);
       this.set('responded', true);
       this.closeModal();
 

--- a/app/components/confirm-modal.js
+++ b/app/components/confirm-modal.js
@@ -56,7 +56,7 @@ export default Component.extend({
         return;
       }
       let fn = this.get(response ? 'resolve' : 'reject');
-      fn.apply(null, this.get('_originalArgs'));
+      fn.apply(null, response ? this.get('_originalArgs'):null);
       this.set('responded', true);
       this.closeModal();
 

--- a/app/controllers/account/job-opening/campaign/applicant-tracking.js
+++ b/app/controllers/account/job-opening/campaign/applicant-tracking.js
@@ -138,8 +138,8 @@ export default Controller.extend(addEdit, ajaxStatus, modalSupport, {
     });
 
     try {
-      await jobApplication.save()
-      await employee.save()
+      await jobApplication.save();
+      await employee.save();
 
       if (wasNew) {
         this.transitionToRoute('account.employee.onboard', employee.get('id'));

--- a/app/controllers/account/job-opening/campaign/applicant-tracking.js
+++ b/app/controllers/account/job-opening/campaign/applicant-tracking.js
@@ -106,14 +106,14 @@ export default Controller.extend(addEdit, ajaxStatus, modalSupport, {
     }
   },
 
-  beginOnboarding (jobApplication) {
+  async beginOnboarding (jobApplication) {
     this.analytics.trackEvent('Recruiting', 'hire', 'Hired candidate');
 
     const job = this.get('model.job'),
           jobOpening = this.get('model.jobOpening'),
-          applicant = jobApplication.get('applicant');
+          applicant  = await jobApplication.get('applicant');
 
-    let employee = jobApplication.get('employee');
+    let employee = await jobApplication.get('employee');
 
     jobApplication.setProperties({
       hired:      true,
@@ -137,14 +137,16 @@ export default Controller.extend(addEdit, ajaxStatus, modalSupport, {
       hiredFromJobApp: jobApplication
     });
 
-    return jobApplication.save()
-    .then(() => employee.save())
-    .then(employeeRecord => {
+    try {
+      await jobApplication.save()
+      await employee.save()
+
       if (wasNew) {
-        this.transitionToRoute('account.employee.onboard', employeeRecord.get('id'));
+        this.transitionToRoute('account.employee.onboard', employee.get('id'));
       }
-    })
-    .catch(this.ajaxError.bind(this));
+    } catch (e) {
+      this.ajaxError(e);
+    }
   },
 
   actions: {


### PR DESCRIPTION
Closes #725 
confirm modal change is for the issue.  APS change was for a new bug I found, wouldn't let you hire an employee that was internal.

[rn] fixed 'no' button on recruiting, when the user clicks `hire candidate`  and fixed error for hiring an internal employee from recruiting