### PR TITLE
[Bug] assets don't refresh employee/onboarding AND header doesn't display the category

### DIFF
--- a/app/controllers/account/employee/onboard/equipment.js
+++ b/app/controllers/account/employee/onboard/equipment.js
@@ -133,7 +133,6 @@ export default Controller.extend(ajaxStatus, {
 
       if (assignment) {
         this.ajaxStart();
-
         asset.get('assignments').removeObject(assignment);
 
         asset.save()


### PR DESCRIPTION
closes #752, closes #726

and for a bonus fixed an issue where an asset would be added and it would be there twice, one without an ID

![image](https://user-images.githubusercontent.com/25805625/76007476-54111880-5ecb-11ea-8f5f-de4c159ec0d3.png)

adding the asset, showing it adds to the list of assets

![image](https://user-images.githubusercontent.com/25805625/76007517-65f2bb80-5ecb-11ea-889d-9e3813f48cc7.png)

showing the category for a previous group and a newly created on the fly onboarding

![image](https://user-images.githubusercontent.com/25805625/76007599-8884d480-5ecb-11ea-8f6a-3e15a84ccd9b.png)

![image](https://user-images.githubusercontent.com/25805625/76007696-b23dfb80-5ecb-11ea-9fbe-eef0b5587033.png)



