### PR TITLE
[Bug] Summary link not scoped to index in educate tab

### DIFF
--- a/app/templates/account/education.hbs
+++ b/app/templates/account/education.hbs
@@ -1,6 +1,6 @@
 <div class="ui container basic segment">
   <UiMenu @menuClass="pointing menu__education-page">
-    <LinkTo @route="account.education" class="item">
+    <LinkTo @route="account.education.index" class="item">
       <i class="list icon"></i>Summary
     </LinkTo>
     <LinkTo @route="account.education.webinars" class="item">


### PR DESCRIPTION
closes #784

![image](https://user-images.githubusercontent.com/25805625/89670099-db5d2080-d89d-11ea-9c5c-8185300584bb.png)

![image](https://user-images.githubusercontent.com/25805625/89670119-e2842e80-d89d-11ea-807e-b06feba3bad7.png)
